### PR TITLE
Ref: Covid Requests To DRY && Clean Daily Checks

### DIFF
--- a/functions/msdatacrawler-background.js
+++ b/functions/msdatacrawler-background.js
@@ -1,57 +1,42 @@
 const axios = require('axios')
-const cheerio = require('cheerio')
+// This is ultimately a personal choice. The '$' below drives me nuts
+// So, the result of cheerioAPI.load is 'cheerio' instead of `$`;
+const cheerioApi = require('cheerio')
 const fs = require('fs')
 const data = require('../src/constants/covidData.json')
 
 const msdh = 'https://msdh.ms.gov/msdhsite/_static/14,0,420.html'
 
-const getDailyCases = async () => {
-  try {
-    const { data } = await axios.get(msdh)
-    const $ = cheerio.load(data);
-    let dailyCases = parseInt($('[data-description="New cases"]').text().replace(/,/g, ''))
+// To Assists with Enumeration
+// And Object Assign for `daily` data.
+const DataPonits = {
+  newCases: 'New cases',
+  totalCases: 'Total MS cases',
+  newDeaths: 'New deaths',
+  testsRun: 'Total tests PCR',
+};
 
-    return dailyCases
-  } catch (error) {
-    throw error;
-  }
-}
+const cheeriax = (dataPoint) => {
+  let result = null;
+  return async () => {
+    try {
+      const response = await axios.get(msdh);
+      const cheerio = cheerioApi.load(response.data);
 
-const getTotalCases = async () => {
-  try {
-    const { data } = await axios.get(msdh)
-    const $ = cheerio.load(data);
-    let total = parseInt($('[data-description="Total MS cases"]').text().replace(/,/g, ''))
+      result = parseInt(cheerio(`[data-description="${dataPoint}"]`).text().replace(/,/g, ''));
+    } catch (error) {
+      // Consider Logging Error to file
+      throw error;
+    } finally {
+      return result;
+    }
+  };
+};
 
-    return total
-  } catch (error) {
-    throw error;
-  }
-}
-
-const getDailyDeaths = async () => {
-  try {
-    const { data } = await axios.get(msdh)
-    const $ = cheerio.load(data);
-    let deaths = parseInt($('[data-description="New deaths"]').text().replace(/,/g, ''))
-
-    return deaths
-  } catch (error) {
-    throw error;
-  }
-}
-
-const getTestsRun = async () => {
-  try {
-    const { data } = await axios.get(msdh)
-    const $ = cheerio.load(data);
-    let tests = parseInt($('[data-description="Total tests PCR"]').text().replace(/,/g, ''))
-
-    return tests
-  } catch (error) {
-    throw error;
-  }
-}
+const getDailyCases = cheeriax(DataPonits.newCases);
+const getTotalCases = cheeriax(DataPonits.totalCases);
+const getDailyDeaths = cheeriax(DataPonits.newDeaths);
+const getTestsRun = cheeriax(DataPonits.testsRun);
 
 let today = new Date()
 today.setDate(today.getDate() - 1) //subtracting one from day because this will always be data from the previous day
@@ -59,13 +44,11 @@ today.setDate(today.getDate() - 1) //subtracting one from day because this will 
 //for correct date formatting
 let day = today.getDate() < 10 ? '0' + today.getDate() : today.getDate()
 let month = (today.getMonth() + 1) < 10 ? '0' + (today.getMonth() + 1) : (today.getMonth() + 1)
-let daily = {
-  date: today.getFullYear() + '-' + month + '-' + day,
-  newCases: 0,
-  newDeaths: 0,
-  totalCases: 0,
-  testsRun: 0
-}
+
+// Spread our Data Point Object into our Daily Results
+// The Values will be overwritten with the result of calling cheeriax
+// No need to worry that the values are currently strings
+const daily = { date: `${today.getFullYear()}-${month}-${day}`, ...DataPonits };
 
 const getCovidData = async () => {
   await getDailyDeaths().then((dailyDeaths) => daily.newDeaths = dailyDeaths)
@@ -73,7 +56,15 @@ const getCovidData = async () => {
   await getDailyCases().then((dailyCases) => daily.newCases = dailyCases)
   await getTotalCases().then((total) => daily.totalCases = total)
 
-  if (!data.data.includes(daily.date) && daily.newCases != 0) {
+  // await getDailyDeaths().then((dailyDeaths) => (daily.newDeaths = dailyDeaths || 0));
+  // await getTestsRun().then((tests) => (daily.testsRun = tests || 0));
+  // await getDailyCases().then((dailyCases) => (daily.newCases = dailyCases || 0));
+  // await getTotalCases().then((total) => (daily.totalCases = total || 0));
+  
+  // NewCases will either exist as a number or not at all.
+  // daily.newCases will be the result of cheeriax => null(falsy) | NaN(falsy) | number
+  // If concerned, replace your awaits with the commented awaits above
+  if (!data.data.includes(daily.date) && daily.newCases) { 
     data.data.push(daily)
 
     fs.writeFile('src/constants/covidData.json', JSON.stringify(data), (err) => {


### PR DESCRIPTION
I read your article and was inspired to do the same for my wife.
I was also curious to your approach. So, I hope you don't mind me taking the liberty to assist. 

There isn't much here, mainly: 
1. a refactor of the outbound network request
2. a spread of the Points object into our Daily results container.
3. a simple dailyCase check.

I left comments in the code for you. Feel free to reject but, thanks for considering.
I admit though, I don't recall the response of Cheerio if there is an internal error with load.
You may want to guard against that. But, if load throws, you'll be ok since it'll be caught and null returned from finally.